### PR TITLE
fix compile error on Linux (file names are case sensitive)

### DIFF
--- a/Firmware/Mechaduino/Cmd.cpp
+++ b/Firmware/Mechaduino/Cmd.cpp
@@ -255,7 +255,7 @@ void insert_command(const char* command_string) {
   strcpy(buf, command_string);
 
   uint8_t msg_length = 0;
-  while ((msg_length < 30) && buf[msg_length] != NULL) {
+  while ((msg_length < 30) && buf[msg_length] != 0) {
     cmd_handler( buf[msg_length]);
     msg_length++;
   }
@@ -314,4 +314,3 @@ bool userqst(int timeout, const String qst_string) {
   return answer;
 
 }
-

--- a/Firmware/Mechaduino/Configuration.h
+++ b/Firmware/Mechaduino/Configuration.h
@@ -1,7 +1,7 @@
 
 #ifndef __CONFIGURATION_H__
 #define __CONFIGURATION_H__
-#include <arduino.h>
+#include <Arduino.h>
 
 
 #if defined(__SAMD51__)
@@ -93,7 +93,3 @@ extern int error_LPF;
 #define FPID 5000
 #define Fs (5*FPID)
 #endif
-
-
-
-

--- a/Firmware/Mechaduino/Serial.h
+++ b/Firmware/Mechaduino/Serial.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include <arduino.h>
+#include <Arduino.h>
 
 
 

--- a/Firmware/Mechaduino/State.h
+++ b/Firmware/Mechaduino/State.h
@@ -3,7 +3,7 @@
 #ifndef __STATE_H__
 #define __STATE_H__
 #include <stdint.h>
-#include <arduino.h>
+#include <Arduino.h>
 
 //---- interrupt vars ----
 extern volatile int r;            //target angle

--- a/Firmware/Mechaduino/Utils.h
+++ b/Firmware/Mechaduino/Utils.h
@@ -3,7 +3,7 @@
 #ifndef __UTILS_H__
 #define __UTIL_H__
 #pragma once
-#include <arduino.h>
+#include <Arduino.h>
 
 void boot();
 
@@ -52,4 +52,3 @@ void getCoggingTable(int arg_cnt, char **args);
 int rateLimiter(int currentValue, int lastValue, int RSR, int FSR);
 
 #endif
-


### PR DESCRIPTION
I compiled on Linux and had to change arduino.h to Arduino.h.

I also got an error because of comparing a char value to a void* (NULL).
I think, C++ source usually shouldn't use NULL anyways, it's kind of an old C macro mainly created for type safety in C and not necessary in C++.